### PR TITLE
BoneTrigger now doesn't shoot at enemies with spawn protection.

### DIFF
--- a/src/main/kotlin/rat/poison/game/entity/Player.kt
+++ b/src/main/kotlin/rat/poison/game/entity/Player.kt
@@ -27,6 +27,7 @@ import rat.poison.game.*
 import rat.poison.game.netvars.NetVarOffsets.ArmorValue
 import rat.poison.game.netvars.NetVarOffsets.aimPunchAngle
 import rat.poison.game.netvars.NetVarOffsets.angEyeAngles
+import rat.poison.game.netvars.NetVarOffsets.bGunGameImmunity
 import rat.poison.game.offsets.ClientOffsets.dwIndex
 import rat.poison.game.offsets.EngineOffsets
 import rat.poison.utils.*
@@ -216,3 +217,5 @@ internal fun Player.hltv(): Boolean {
 	mem.dump()
 	return hltvB
 }
+
+internal fun Player.isProtected(): Boolean = csgoEXE.boolean(this + bGunGameImmunity)

--- a/src/main/kotlin/rat/poison/game/netvars/NetVarOffsets.kt
+++ b/src/main/kotlin/rat/poison/game/netvars/NetVarOffsets.kt
@@ -24,6 +24,7 @@ object NetVarOffsets {
 	val nTickBase by netVar("DT_BasePlayer")
 
 	val flFlashMaxAlpha by netVar("DT_CSPlayer")
+	val bGunGameImmunity by netVar("DT_CSPlayer")
 	val iCrossHairID by netVar("DT_CSPlayer", "m_bHasDefuser", 0x5C)
 	val iShotsFired by netVar("DT_CSPlayer")
 	val bIsScoped by netVar("DT_CSPlayer")

--- a/src/main/kotlin/rat/poison/scripts/BoneTrigger.kt
+++ b/src/main/kotlin/rat/poison/scripts/BoneTrigger.kt
@@ -15,6 +15,7 @@ import rat.poison.scripts.aim.findTarget
 import rat.poison.settings.*
 import rat.poison.utils.*
 import rat.poison.curSettings
+import rat.poison.game.entity.isProtected
 import rat.poison.game.entity.position
 import rat.poison.game.entity.weapon
 import rat.poison.opened
@@ -37,7 +38,8 @@ private val onBoneTriggerTarget = every(4) {
                 if (curSettings["ENABLE_BONE_TRIGGER"]!!.strToBool()) {
                     val currentAngle = clientState.angle()
                     val position = me.position()
-                    if (findTarget(position, currentAngle, false, curSettings["BONE_TRIGGER_FOV"]!!.toInt(), -2) >= 0) {
+                    val target = findTarget(position, currentAngle, false, curSettings["BONE_TRIGGER_FOV"]!!.toInt(), -2)
+                    if (target >= 0 && !target.isProtected()) {
                         if ((keyReleased(curSettings["FIRE_KEY"]!!.toInt()) && curSettings["BONE_TRIGGER_ENABLE_KEY"]!!.strToBool() && keyPressed(curSettings["BONE_TRIGGER_KEY"]!!.toInt())) || (keyReleased(FIRE_KEY) && !curSettings["BONE_TRIGGER_ENABLE_KEY"]!!.strToBool())) {
                             boneTrig = curSettings["AIM_ON_BONE_TRIGGER"]!!.strToBool()
                             boneTrigger()


### PR DESCRIPTION
Before: The BoneTrigger did shoot at enemies which are protected.

Now: The BoneTrigger shoots only at enemies that are not protected.