### PR TITLE
beta: no more jcenter

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -26,5 +26,10 @@
       <option name="name" value="maven2" />
       <option name="url" value="https://oss.sonatype.org/content/repositories/snapshots/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="Gradle Central Plugin Repository" />
+      <option name="name" value="Gradle Central Plugin Repository" />
+      <option name="url" value="https://plugins.gradle.org/m2" />
+    </remote-repository>
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -3,12 +3,9 @@
   <component name="Kotlin2JsCompilerArguments">
     <option name="sourceMapEmbedSources" />
   </component>
-  <component name="Kotlin2JvmCompilerArguments">
-    <option name="jvmTarget" value="1.8" />
-  </component>
   <component name="KotlinCommonCompilerArguments">
-    <option name="apiVersion" value="1.4" />
-    <option name="languageVersion" value="1.4" />
+    <option name="apiVersion" value="1.5" />
+    <option name="languageVersion" value="1.5" />
   </component>
   <component name="KotlinCompilerSettings">
     <option name="additionalArguments" value="-version -Xskip-runtime-version-check" />

--- a/build.gradle
+++ b/build.gradle
@@ -2,19 +2,20 @@ import java.nio.file.Files
 import org.apache.commons.io.FileUtils
 
 buildscript {
-	ext.kotlin_version = '1.4.21'
-	ext.jnaVersion = '5.6.0'
-	ext.gdxVersion = '1.9.14'
+	ext.kotlin_version = '1.5.31'
+	ext.jnaVersion = '5.9.0'
+	ext.gdxVersion = '1.10.0'
 	ext.visuiVersion = "1.5.0"
 
 	repositories {
-		jcenter()
+		mavenCentral()
+		gradlePluginPortal()
 	}
 
 	dependencies {
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-		classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'
-		classpath "commons-io:commons-io:2.8.0"
+		classpath 'gradle.plugin.com.github.johnrengelman:shadow:7.1.0'
+		classpath "commons-io:commons-io:2.11.0"
 	}
 }
 
@@ -33,9 +34,8 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
-	jcenter()
 	maven { url 'https://jitpack.io' }
-	maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+	gradlePluginPortal()
 }
 
 dependencies {
@@ -56,16 +56,16 @@ dependencies {
 	implementation group: 'org.jetbrains.kotlin', name: 'kotlin-script-util', version: kotlin_version
 	implementation group: 'org.jetbrains.kotlin', name: 'kotlin-compiler-embeddable', version: kotlin_version
 
-	implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
+	implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 	implementation 'com.github.ata4:ioutils:b1f26588b5'
 	implementation 'com.github.ata4:bspsrc:v1.3.24'
 
 	implementation group: 'it.unimi.dsi', name: 'fastutil', version: '8.4.4'
 
-	implementation group: 'net.openhft', name: 'chronicle-core', version: '2.20.125'
-	implementation "io.ktor:ktor-client-websockets:1.5.2"
-	implementation "io.ktor:ktor-client-okhttp:1.5.2"
-	implementation 'com.google.code.gson:gson:2.8.6'
+	implementation group: 'net.openhft', name: 'chronicle-core', version: '2.21.92'
+	implementation "io.ktor:ktor-client-websockets:1.5.4"
+	implementation "io.ktor:ktor-client-okhttp:1.5.4"
+	implementation 'com.google.code.gson:gson:2.8.8'
 	implementation "org.slf4j:slf4j-nop:1.7.31"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Mon Dec 02 21:43:01 CST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/rat/poison/game/hooks/EntityIteration.kt
+++ b/src/main/kotlin/rat/poison/game/hooks/EntityIteration.kt
@@ -78,7 +78,7 @@ private var signOnState by Delegates.observable(SignOnState.MAIN_MENU) { _, old,
 
             //Find correct tonemap values
 //        File("$SETTINGS_DIRECTORY\\Data\\ToneMaps.txt").forEachLine { line ->
-//            if (mapName.toLowerCase().contains(line.split(" : ")[0].toLowerCase())) {
+//            if (mapName.lowercase().contains(line.split(" : ")[0].lowercase())) {
 //                //this is working... not needed for now
 //            }
 //        }

--- a/src/main/kotlin/rat/poison/utils/extensions/StringExtensions.kt
+++ b/src/main/kotlin/rat/poison/utils/extensions/StringExtensions.kt
@@ -7,7 +7,7 @@ fun String.upper(): String {
     val get = upperCaseCache[this]
     return when (get == null) {
         true -> {
-            val tmpStr = this.toUpperCase()
+            val tmpStr = this.uppercase()
             upperCaseCache[this] = tmpStr
             tmpStr
         }
@@ -20,7 +20,7 @@ fun String.lower(): String {
     val get = lowerCaseCache[this]
     return when (get == null) {
         true -> {
-            val tmpStr = this.toLowerCase()
+            val tmpStr = this.lowercase()
             lowerCaseCache[this] = tmpStr
             tmpStr
         }


### PR DESCRIPTION
* Gradle 6.7.2 -> 7.2 bump
* Kotlin 1.4.21 -> 1.5.31 bump
* Other dependencies bumped

fastutil with versions higher than 8.4.4 throws error below, so kept at that.
```
Exception in thread "Thread-4" java.lang.UnsupportedOperationException
        at it.unimi.dsi.fastutil.objects.ObjectLists$Singleton.remove(ObjectLists.java:243)
        at it.unimi.dsi.fastutil.objects.ObjectLists$SynchronizedList.remove(ObjectLists.java:433)
        at rat.poison.utils.WebSocket.initialize$lambda-0(Socketing.kt:31)
        at java.base/java.lang.Thread.run(Thread.java:832)
```
ktor with version higher than 1.5.4 throws warning below, since server is down and couldn't test it, only minor version bump.
```
'KtorExperimentalAPI' is deprecated. This annotation is no longer used and there is no need to opt-in into it.
```
---
Playtime of 20 mins, offline comp and arms race, no errors other than shared esp server timeout, cheat seems to behave fine.